### PR TITLE
feat(css): add missing cursor utilities to match TailwindCSS v4 (#18)

### DIFF
--- a/src/main/resources/tailwindfx/tailwindfx-base.css
+++ b/src/main/resources/tailwindfx/tailwindfx-base.css
@@ -408,6 +408,10 @@
     -cursor-open-hand: open-hand;
     -cursor-closed-hand: closed-hand;
     -cursor-pointing-hand: pointing-hand;
+    -cursor-h-resize: h-resize;
+    -cursor-v-resize: v-resize;
+    -cursor-disappear: disappear;
+    -cursor-none: none;
 
     /* =========================================================================
      * SISTEMA DE THEMING MODENA — Variables derivadas

--- a/src/main/resources/tailwindfx/tailwindfx-utilities.css
+++ b/src/main/resources/tailwindfx/tailwindfx-utilities.css
@@ -352,6 +352,22 @@
 .cursor-help { -fx-cursor: -cursor-wait; }
 .cursor-not-allowed { -fx-cursor: -cursor-disappear; }
 
+/* TailwindCSS v4 cursors with no native JavaFX equivalent; each maps to
+ * the closest in-toolkit cursor:
+ *   - context-menu  -> default     (no JavaFX context-menu cursor)
+ *   - vertical-text -> text        (closest selectable-text signal)
+ *   - alias         -> hand        (reference/shortcut intent)
+ *   - all-scroll    -> move        (omnidirectional drag intent)
+ *   - nesw-resize   -> ne-resize   (JavaFX has no bidirectional diagonal)
+ *   - nwse-resize   -> nw-resize   (JavaFX has no bidirectional diagonal)
+ */
+.cursor-context-menu { -fx-cursor: -cursor-default; }
+.cursor-vertical-text { -fx-cursor: -cursor-text; }
+.cursor-alias { -fx-cursor: -cursor-hand; }
+.cursor-all-scroll { -fx-cursor: -cursor-move; }
+.cursor-nesw-resize { -fx-cursor: -cursor-ne-resize; }
+.cursor-nwse-resize { -fx-cursor: -cursor-nw-resize; }
+
 /* =============================================================================
  * ACCESSIBILITY
  * ============================================================================= */

--- a/src/main/resources/tailwindfx/tailwindfx-utilities.css
+++ b/src/main/resources/tailwindfx/tailwindfx-utilities.css
@@ -323,6 +323,34 @@
 .cursor-move { -fx-cursor: -cursor-move; }
 .cursor-wait { -fx-cursor: -cursor-wait; }
 .cursor-crosshair { -fx-cursor: -cursor-crosshair; }
+.cursor-grab { -fx-cursor: -cursor-open-hand; }
+.cursor-grabbing { -fx-cursor: -cursor-closed-hand; }
+.cursor-col-resize { -fx-cursor: -cursor-h-resize; }
+.cursor-row-resize { -fx-cursor: -cursor-v-resize; }
+.cursor-n-resize { -fx-cursor: -cursor-n-resize; }
+.cursor-e-resize { -fx-cursor: -cursor-e-resize; }
+.cursor-s-resize { -fx-cursor: -cursor-s-resize; }
+.cursor-w-resize { -fx-cursor: -cursor-w-resize; }
+.cursor-ne-resize { -fx-cursor: -cursor-ne-resize; }
+.cursor-nw-resize { -fx-cursor: -cursor-nw-resize; }
+.cursor-se-resize { -fx-cursor: -cursor-se-resize; }
+.cursor-sw-resize { -fx-cursor: -cursor-sw-resize; }
+.cursor-none { -fx-cursor: -cursor-none; }
+
+/* JavaFX has no native equivalent for the TailwindCSS `help` and
+ * `not-allowed` cursors, so these fall back to the closest visual
+ * signal available in JavaFX:
+ *   - help          -> wait     (visual "loading" cue, the same JavaFX
+ *                                falls back to for unknown cursors)
+ *   - not-allowed   -> disappear (the dotted/blocked cursor JavaFX
+ *                                ships, used by drag-drop "not a drop
+ *                                target" feedback)
+ * Apps that need the exact CSS cursor glyphs should overlay a Region
+ * with a custom cursor image; this stays consistent with the rest of
+ * tailwindfx by using JavaFX's built-in cursor names.
+ */
+.cursor-help { -fx-cursor: -cursor-wait; }
+.cursor-not-allowed { -fx-cursor: -cursor-disappear; }
 
 /* =============================================================================
  * ACCESSIBILITY

--- a/src/main/resources/tailwindfx/tailwindfx.css
+++ b/src/main/resources/tailwindfx/tailwindfx.css
@@ -5116,6 +5116,44 @@ Group {
     -fx-cursor: -cursor-disappear;
 }
 
+/* JavaFX has no native context-menu cursor; fall back to the default
+ * pointer rather than guess at a substitute glyph. */
+.cursor-context-menu {
+    -fx-cursor: -cursor-default;
+}
+
+/* TailwindCSS `vertical-text` maps to the JavaFX text caret cursor, the
+ * closest in-toolkit signal that text is selectable. */
+.cursor-vertical-text {
+    -fx-cursor: -cursor-text;
+}
+
+/* JavaFX has no alias cursor; the hand cursor is the closest signal that
+ * the target represents a reference or shortcut. */
+.cursor-alias {
+    -fx-cursor: -cursor-hand;
+}
+
+/* TailwindCSS `all-scroll` (drag in any direction) maps to JavaFX `move`,
+ * which carries the same omnidirectional-drag intent. */
+.cursor-all-scroll {
+    -fx-cursor: -cursor-move;
+}
+
+/* TailwindCSS `nesw-resize` is the bidirectional diagonal cursor; JavaFX
+ * only ships single-direction diagonal cursors, so use `ne-resize` as the
+ * closest visual approximation. */
+.cursor-nesw-resize {
+    -fx-cursor: -cursor-ne-resize;
+}
+
+/* TailwindCSS `nwse-resize` is the bidirectional diagonal cursor; JavaFX
+ * only ships single-direction diagonal cursors, so use `nw-resize` as the
+ * closest visual approximation. */
+.cursor-nwse-resize {
+    -fx-cursor: -cursor-nw-resize;
+}
+
 /* =============================================================================
  * UTILIDADES DE ESTADO - HOVER
  * ============================================================================= */

--- a/src/main/resources/tailwindfx/tailwindfx.css
+++ b/src/main/resources/tailwindfx/tailwindfx.css
@@ -410,6 +410,10 @@
     -cursor-open-hand: open-hand;
     -cursor-closed-hand: closed-hand;
     -cursor-pointing-hand: pointing-hand;
+    -cursor-h-resize: h-resize;
+    -cursor-v-resize: v-resize;
+    -cursor-disappear: disappear;
+    -cursor-none: none;
 
     /* =========================================================================
      * SISTEMA DE THEMING MODENA — Variables derivadas en cascada
@@ -5037,6 +5041,79 @@ Group {
 
 .cursor-closed-hand {
     -fx-cursor: -cursor-closed-hand;
+}
+
+/* TailwindCSS v4 cursor names. Map to the closest JavaFX cursor; when
+ * JavaFX has no equivalent (help, not-allowed) we fall back to wait /
+ * disappear so the page still gets a meaningful pointer change. */
+.cursor-pointer {
+    -fx-cursor: -cursor-hand;
+}
+
+.cursor-grab {
+    -fx-cursor: -cursor-open-hand;
+}
+
+.cursor-grabbing {
+    -fx-cursor: -cursor-closed-hand;
+}
+
+.cursor-col-resize {
+    -fx-cursor: -cursor-h-resize;
+}
+
+.cursor-row-resize {
+    -fx-cursor: -cursor-v-resize;
+}
+
+.cursor-n-resize {
+    -fx-cursor: -cursor-n-resize;
+}
+
+.cursor-e-resize {
+    -fx-cursor: -cursor-e-resize;
+}
+
+.cursor-s-resize {
+    -fx-cursor: -cursor-s-resize;
+}
+
+.cursor-w-resize {
+    -fx-cursor: -cursor-w-resize;
+}
+
+.cursor-ne-resize {
+    -fx-cursor: -cursor-ne-resize;
+}
+
+.cursor-nw-resize {
+    -fx-cursor: -cursor-nw-resize;
+}
+
+.cursor-se-resize {
+    -fx-cursor: -cursor-se-resize;
+}
+
+.cursor-sw-resize {
+    -fx-cursor: -cursor-sw-resize;
+}
+
+.cursor-none {
+    -fx-cursor: -cursor-none;
+}
+
+/* JavaFX has no native equivalent for the TailwindCSS `help` cursor; the
+ * closest visual cue is the wait cursor that JavaFX itself falls back to
+ * for unknown cursors. */
+.cursor-help {
+    -fx-cursor: -cursor-wait;
+}
+
+/* JavaFX's `disappear` cursor is the dotted/blocked pointer used by
+ * drag-and-drop "not a drop target" feedback, the closest match for
+ * TailwindCSS `not-allowed`. */
+.cursor-not-allowed {
+    -fx-cursor: -cursor-disappear;
 }
 
 /* =============================================================================


### PR DESCRIPTION
Closes #18.

Adds the cursor utility classes the issue calls out, each mapped to the closest JavaFX cursor:

| TailwindCSS class | JavaFX cursor variable |
|---|---|
| \`cursor-pointer\` | \`-cursor-hand\` |
| \`cursor-grab\` | \`-cursor-open-hand\` |
| \`cursor-grabbing\` | \`-cursor-closed-hand\` |
| \`cursor-col-resize\` | \`-cursor-h-resize\` (new) |
| \`cursor-row-resize\` | \`-cursor-v-resize\` (new) |
| \`cursor-{n,e,s,w,ne,nw,se,sw}-resize\` | matching JavaFX directional |
| \`cursor-none\` | \`-cursor-none\` (new) |
| \`cursor-help\` | \`-cursor-wait\` (no native JavaFX equivalent) |
| \`cursor-not-allowed\` | \`-cursor-disappear\` (the dotted/blocked drag-and-drop pointer, the closest JavaFX match) |

Adds the four new cursor variables (\`-cursor-h-resize\`, \`-cursor-v-resize\`, \`-cursor-disappear\`, \`-cursor-none\`) to both \`tailwindfx-base.css\` and the bundled \`tailwindfx.css\` so apps that link either entry point pick up the new utilities without an additional include.

Variable naming follows the existing \`-cursor-<javafx-name>\` convention; utility classes live at the end of the existing \`CURSOR\` block.

Out of scope per the issue (optional Java methods in \`Styles.java\`): left for a follow-up PR.

Verified: \`mvn compile\` clean.