### PR TITLE
refactor: implement Publisher-Subscriber pattern for responsive breakpoints

### DIFF
--- a/src/main/java/tailwindfx/BreakpointManager.java
+++ b/src/main/java/tailwindfx/BreakpointManager.java
@@ -1,5 +1,7 @@
 package tailwindfx;
 
+import javafx.beans.property.ObjectProperty;
+import javafx.beans.property.SimpleObjectProperty;
 import javafx.beans.value.ChangeListener;
 import javafx.scene.Scene;
 import javafx.stage.Stage;
@@ -8,45 +10,54 @@ import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.List;
 import java.util.Objects;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Consumer;
 
 /**
- * BreakpointManager v2 — Responsive engine de TailwindFX.
- *
- * En JavaFX no existen @media queries. Este engine los simula:
- *   1. Escucha Stage.widthProperty() (y opcionalmente heightProperty)
- *   2. Calcula el breakpoint activo
- *   3. Inyecta clases CSS acumulativas en el root de la Scene (.bp-sm, .bp-md…)
- *   4. Ejecuta callbacks registrados al cruzar cada breakpoint
- *
- * Breakpoints por defecto (iguales a Tailwind):
- *   XS  < 640px   → sin clase
+ * BreakpointManager v2 — Responsive engine for TailwindFX.
+ * 
+ * JavaFX does not have @media queries. This engine simulates them:
+ *   1. Listens to Stage.widthProperty() (and optionally heightProperty)
+ *   2. Calculates the active breakpoint
+ *   3. Injects cumulative CSS classes into the Scene root (.bp-sm, .bp-md...)
+ *   4. Executes registered callbacks when crossing each breakpoint
+ * 
+ * Default breakpoints (same as Tailwind):
+ *   XS  < 640px   → no class
  *   SM  ≥ 640px   → .bp-sm
  *   MD  ≥ 768px   → .bp-sm .bp-md
  *   LG  ≥ 1024px  → .bp-sm .bp-md .bp-lg
  *   XL  ≥ 1280px  → .bp-sm .bp-md .bp-lg .bp-xl
  *   2XL ≥ 1536px  → .bp-sm .bp-md .bp-lg .bp-xl .bp-2xl
- *
- * Las clases son ACUMULATIVAS como en Tailwind.
- * .bp-lg implica que también .bp-sm y .bp-md están activas.
- *
- * Uso básico:
+ * 
+ * Classes are CUMULATIVE like in Tailwind.
+ * .bp-lg implies that .bp-sm and .bp-md are also active.
+ * 
+ * Basic usage:
  *   TailwindFX.responsive(stage)
  *       .onBreakpoint(Breakpoint.MD, () -> adaptLayout());
- *
- * Con breakpoints custom:
+ * 
+ * With custom breakpoints:
  *   BreakpointManager.custom()
  *       .add("phone",  0)
  *       .add("tablet", 600)
  *       .add("desktop", 960)
  *       .attach(stage);
- *
- * CSS en tailwindfx.css:
+ * 
+ * CSS in tailwindfx.css:
  *   .bp-md .sidebar  { -fx-pref-width: 240px; }
  *   .bp-sm .sidebar  { -fx-pref-width: 60px;  }
  *   .bp-lg .card-grid { -fx-vgap: 20px; }
+ * 
+ * Architecture: Publisher pattern
+ * - Single listener per Stage with throttling (~120ms)
+ * - Exposes activeBreakpointProperty() for subscribers (e.g., VariantManager)
+ * - Prevents O(N) listeners by centralizing breakpoint detection
  */
 public final class BreakpointManager {
+
+    // Cache of BreakpointManager instances per Stage
+    private static final ConcurrentHashMap<Stage, BreakpointManager> instances = new ConcurrentHashMap<>();
 
     // =========================================================================
     // Breakpoints
@@ -99,7 +110,7 @@ public final class BreakpointManager {
     }
 
     // =========================================================================
-    // Builder para breakpoints custom
+    // Builder for custom breakpoints
     // =========================================================================
 
     public static final class CustomBuilder {
@@ -118,11 +129,22 @@ public final class BreakpointManager {
 
     private record CustomBreakpoint(String cssClass, double minWidth) {}
 
-    /** Crea un builder para breakpoints personalizados */
+    /** Creates a builder for custom breakpoints */
     public static CustomBuilder custom() { return new CustomBuilder(); }
 
+    /**
+     * Gets or creates a BreakpointManager instance for the given Stage.
+     * Uses a cache to ensure only one instance per Stage.
+     * 
+     * @param stage The stage to get the BreakpointManager for
+     * @return The BreakpointManager instance
+     */
+    public static BreakpointManager from(Stage stage) {
+        return instances.computeIfAbsent(stage, s -> new BreakpointManager(s, null));
+    }
+
     // =========================================================================
-    // Estado
+    // State
     // =========================================================================
 
     private final Stage  stage;
@@ -134,37 +156,41 @@ public final class BreakpointManager {
     private ChangeListener<Number>           heightListener;
     private boolean                          orientationEnabled = false;
     
-    // Throttle para evitar thrashing en resize
+    // Throttle to avoid thrashing on resize
     private long lastUpdate = 0;
     private static final long THROTTLE_MS = 120;
     
-    // Set para evitar callbacks duplicados
+    // Set to prevent duplicate callbacks
     private final java.util.Set<String> registeredCallbacks = new java.util.HashSet<>();
+    
+    // Property for reactive breakpoint changes (Publisher pattern)
+    private final ObjectProperty<Breakpoint> activeBreakpoint;
 
     // =========================================================================
-    // Construcción
+    // Construction
     // =========================================================================
 
     private BreakpointManager(Stage stage, List<CustomBreakpoint> custom) {
         this.stage     = Preconditions.requireNonNull(stage, "BreakpointManager", "stage");
         this.customBps = custom;
         this.current   = Breakpoint.forWidth(stage.getWidth());
+        this.activeBreakpoint = new SimpleObjectProperty<>(current);
         attachWidthListener();
     }
 
-    /** Crea con breakpoints por defecto (Tailwind) */
+    /** Creates with default breakpoints (Tailwind) */
     static BreakpointManager attach(Stage stage) {
         return new BreakpointManager(stage, null);
     }
 
     // =========================================================================
-    // API pública
+    // Public API
     // =========================================================================
 
     /**
-     * Registra un callback que se ejecuta al cruzar un breakpoint
-     * (tanto al subir como al bajar).
-     * Evita duplicados: si ya está registrado el mismo callback para este breakpoint, no lo añade.
+     * Registers a callback that executes when crossing a breakpoint
+     * (both up and down).
+     * Prevents duplicates: if the same callback is already registered for this breakpoint, it won't be added again.
      */
     public BreakpointManager onBreakpoint(Breakpoint bp, Runnable callback) {
         Preconditions.requireNonNull(bp, "BreakpointManager.onBreakpoint", "breakpoint");
@@ -172,7 +198,7 @@ public final class BreakpointManager {
         
         String key = bp.name() + ":" + System.identityHashCode(callback);
         if (!registeredCallbacks.add(key)) {
-            return this; // Ya está registrado, evitar duplicado
+            return this; // Already registered, avoid duplicate
         }
         
         listeners.add(new BpListener(bp.minWidth, callback));
@@ -180,16 +206,16 @@ public final class BreakpointManager {
     }
 
     /**
-     * Registra un callback con información de si se está activando o desactivando.
-     * active=true → se cruzó hacia arriba (pantalla más grande)
-     * active=false → se cruzó hacia abajo (pantalla más pequeña)
+     * Registers a callback with information about whether it's activating or deactivating.
+     * active=true → crossed upward (larger screen)
+     * active=false → crossed downward (smaller screen)
      */
     public BreakpointManager onBreakpoint(Breakpoint bp, Consumer<Boolean> callback) {
         listeners.add(new BpListener(bp.minWidth, null, callback));
         return this;
     }
 
-    /** Activa detección de orientación (portrait/landscape) */
+    /** Enables orientation detection (portrait/landscape) */
     public BreakpointManager withOrientation() {
         orientationEnabled = true;
         if (stage.getScene() != null)
@@ -201,31 +227,43 @@ public final class BreakpointManager {
         return this;
     }
 
-    /** Breakpoint activo en este momento */
+    /** Currently active breakpoint */
     public Breakpoint current() { return current; }
 
-    /** Si el ancho actual es >= al breakpoint dado */
+    /**
+     * Returns a read-only property of the active breakpoint.
+     * Subscribers can listen to this property to react to breakpoint changes.
+     * This is the main mechanism for the Publisher-Subscriber pattern.
+     * 
+     * @return Read-only property of the active breakpoint
+     */
+    public javafx.beans.property.ReadOnlyObjectProperty<Breakpoint> activeBreakpointProperty() {
+        return activeBreakpoint;
+    }
+
+    /** If current width is >= the given breakpoint */
     public boolean is(Breakpoint bp) { return current.minWidth >= bp.minWidth; }
 
-    /** Si el ancho actual es < al breakpoint dado (below) */
+    /** If current width is < the given breakpoint (below) */
     public boolean below(Breakpoint bp) { return !is(bp); }
 
-    /** Desconecta todos los listeners */
+    /** Disconnects all listeners */
     public void detach() {
         if (widthListener != null) stage.widthProperty().removeListener(widthListener);
         if (heightListener != null) stage.heightProperty().removeListener(heightListener);
         listeners.clear();
         registeredCallbacks.clear();
+        instances.remove(stage);
     }
 
     // =========================================================================
-    // Internos
+    // Internal
     // =========================================================================
 
     private void attachWidthListener() {
         widthListener = (obs, old, newVal) -> update(newVal.doubleValue());
         stage.widthProperty().addListener(widthListener);
-        update(stage.getWidth()); // aplicar estado inicial
+        update(stage.getWidth()); // apply initial state
     }
 
     private void update(double width) {
@@ -248,6 +286,9 @@ public final class BreakpointManager {
 
         Breakpoint prev = current;
         current = next;
+
+        // Update the reactive property (notifies subscribers)
+        activeBreakpoint.set(next);
 
         Scene scene = stage.getScene();
         if (scene != null && scene.getRoot() != null)

--- a/src/main/java/tailwindfx/BreakpointManager.java
+++ b/src/main/java/tailwindfx/BreakpointManager.java
@@ -131,7 +131,15 @@ public final class BreakpointManager {
     private String                           currentCustom;
     private final List<BpListener>           listeners = new ArrayList<>();
     private ChangeListener<Number>           widthListener;
+    private ChangeListener<Number>           heightListener;
     private boolean                          orientationEnabled = false;
+    
+    // Throttle para evitar thrashing en resize
+    private long lastUpdate = 0;
+    private static final long THROTTLE_MS = 120;
+    
+    // Set para evitar callbacks duplicados
+    private final java.util.Set<String> registeredCallbacks = new java.util.HashSet<>();
 
     // =========================================================================
     // Construcción
@@ -156,10 +164,17 @@ public final class BreakpointManager {
     /**
      * Registra un callback que se ejecuta al cruzar un breakpoint
      * (tanto al subir como al bajar).
+     * Evita duplicados: si ya está registrado el mismo callback para este breakpoint, no lo añade.
      */
     public BreakpointManager onBreakpoint(Breakpoint bp, Runnable callback) {
         Preconditions.requireNonNull(bp, "BreakpointManager.onBreakpoint", "breakpoint");
         Preconditions.requireNonNull(callback, "BreakpointManager.onBreakpoint", "callback");
+        
+        String key = bp.name() + ":" + System.identityHashCode(callback);
+        if (!registeredCallbacks.add(key)) {
+            return this; // Ya está registrado, evitar duplicado
+        }
+        
         listeners.add(new BpListener(bp.minWidth, callback));
         return this;
     }
@@ -179,8 +194,10 @@ public final class BreakpointManager {
         orientationEnabled = true;
         if (stage.getScene() != null)
             updateOrientation(stage.getScene(), stage.getWidth(), stage.getHeight());
-        stage.heightProperty().addListener((o, old, h) ->
-            updateOrientation(stage.getScene(), stage.getWidth(), h.doubleValue()));
+        
+        heightListener = (o, old, h) ->
+            updateOrientation(stage.getScene(), stage.getWidth(), h.doubleValue());
+        stage.heightProperty().addListener(heightListener);
         return this;
     }
 
@@ -196,6 +213,9 @@ public final class BreakpointManager {
     /** Desconecta todos los listeners */
     public void detach() {
         if (widthListener != null) stage.widthProperty().removeListener(widthListener);
+        if (heightListener != null) stage.heightProperty().removeListener(heightListener);
+        listeners.clear();
+        registeredCallbacks.clear();
     }
 
     // =========================================================================
@@ -209,11 +229,17 @@ public final class BreakpointManager {
     }
 
     private void update(double width) {
-        if (customBps != null && !customBps.isEmpty()) {
-            updateCustom(width);
-        } else {
-            updateDefault(width);
-        }
+        long now = System.nanoTime();
+        if (now - lastUpdate < THROTTLE_MS * 1_000_000L) return;
+        lastUpdate = now;
+        
+        javafx.application.Platform.runLater(() -> {
+            if (customBps != null && !customBps.isEmpty()) {
+                updateCustom(width);
+            } else {
+                updateDefault(width);
+            }
+        });
     }
 
     private void updateDefault(double width) {
@@ -272,7 +298,7 @@ public final class BreakpointManager {
         if (scene == null || scene.getRoot() == null) return;
         var root = scene.getRoot();
         root.getStyleClass().removeIf(c -> c.equals("portrait") || c.equals("landscape"));
-        root.getStyleClass().add(h > w ? "portrait" : "landscape");
+        root.getStyleClass().add((h > w ? "portrait" : "landscape").trim());
     }
 
     private record BpListener(

--- a/src/main/java/tailwindfx/VariantManager.java
+++ b/src/main/java/tailwindfx/VariantManager.java
@@ -1,94 +1,56 @@
 package tailwindfx;
 
 import javafx.scene.Node;
+import javafx.scene.Scene;
 import java.util.*;
 import java.util.concurrent.ConcurrentHashMap;
 
 /**
- * Gestor de variantes que integra las variantes de Tailwind CSS con JavaFX.
+ * Variant Manager for TailwindFX — Handles variant application to JavaFX nodes.
  * 
- * Maneja la aplicación dinámica de estilos basados en:
- * - Estado (hover, focus, active, disabled)
- * - Breakpoints responsivos (sm, md, lg, xl, 2xl)
- * - Tema (dark, light)
- * - Variantes arbitrarias
+ * This manager applies dynamic styles based on:
+ * - State variants (hover, focus, active, disabled)
+ * - Theme variants (dark, light)
+ * - Group variants (group-hover, group-focus)
+ * - Arbitrary variants ([&:hover], [@media...])
+ * 
+ * IMPORTANT: Responsive breakpoints (sm:, md:, lg:) are NOT handled here.
+ * They are managed centrally by BreakpointManager to avoid O(N) listeners.
+ * This class subscribes ONCE per Scene to breakpoint changes, not per node.
+ * 
+ * Architecture: Publisher-Subscriber pattern
+ * - BreakpointManager: Single publisher (one listener per Stage with throttling)
+ * - VariantManager: Subscriber (one subscription per Scene, iterates affected nodes)
+ * 
+ * @see BreakpointManager
  */
 public class VariantManager {
     
-    private static final Map<Node, List<VariantListener>> nodeListeners = new ConcurrentHashMap<>();
-    private static final Map<String, Integer> breakpointWidths = new HashMap<>();
+    /** Tracks nodes that need responsive variant updates per Scene */
+    private static final Map<Scene, List<ResponsiveBinding>> responsiveNodes = new WeakHashMap<>();
     
-    static {
-        // Definir breakpoints estándar de Tailwind
-        breakpointWidths.put("sm", 640);
-        breakpointWidths.put("md", 768);
-        breakpointWidths.put("lg", 1024);
-        breakpointWidths.put("xl", 1280);
-        breakpointWidths.put("2xl", 1536);
-    }
+    /** Cache of compiled styles for responsive utilities */
+    private static final Map<String, JitCompiler.CompileResult> styleCache = new ConcurrentHashMap<>();
     
     /**
-     * Listener para manejar cambios de variante en un nodo.
-     */
-    @FunctionalInterface
-    public interface VariantListener {
-        void onVariantChange(boolean isActive);
-    }
-    
-    /**
-     * Aplica una variante a un nodo JavaFX.
+     * Applies a state variant (hover, focus, active, disabled) to a JavaFX node.
      * 
-     * @param node El nodo al que aplicar la variante
-     * @param variant El nombre de la variante (hover, focus, md, etc.)
-     * @param utility La utilidad base a aplicar cuando la variante está activa
-     * @param jitCompiler El compilador JIT para generar los estilos
+     * @param node The target node
+     * @param variant The variant name (e.g., "hover", "focus")
+     * @param utility The base utility to apply when variant is active
+     * @param jitCompiler JIT compiler for generating styles
      */
-    public static void applyVariant(Node node, String variant, String utility, JitCompiler jitCompiler) {
+    public static void applyStateVariant(Node node, String variant, String utility, JitCompiler jitCompiler) {
         if (node == null || variant == null || utility == null) {
             return;
         }
         
-        // Determinar el tipo de variante
-        String variantType = VariantParser.getVariantType(variant);
-        
-        switch (variantType) {
-            case "state":
-                applyStateVariant(node, variant, utility, jitCompiler);
-                break;
-            case "screen":
-                applyScreenVariant(node, variant, utility, jitCompiler);
-                break;
-            case "theme":
-                applyThemeVariant(node, variant, utility, jitCompiler);
-                break;
-            case "group":
-                applyGroupVariant(node, variant, utility, jitCompiler);
-                break;
-            case "arbitrary":
-                applyArbitraryVariant(node, variant, utility, jitCompiler);
-                break;
-            default:
-                // Variante no soportada, aplicar directamente
-                JitCompiler.CompileResult result = jitCompiler.compile(utility);
-                if (result != null && result.hasInlineStyle()) {
-                    node.setStyle(node.getStyle() + result.inlineStyle());
-                }
-        }
-    }
-    
-    /**
-     * Aplica una variante de estado (hover, focus, active, etc.).
-     */
-    private static void applyStateVariant(Node node, String variant, String utility, JitCompiler jitCompiler) {
-        // Compilar la utilidad base
+        // Compile the base utility
         JitCompiler.CompileResult result = jitCompiler.compile(utility);
         if (result == null || !result.hasInlineStyle()) {
             return;
         }
         String baseStyle = result.inlineStyle();
-        
-        // Limpiar listeners previos para este nodo
-        cleanupListeners(node);
         
         switch (variant) {
             case "hover":
@@ -143,51 +105,147 @@ public class VariantManager {
     }
     
     /**
-     * Aplica una variante de pantalla responsiva (sm, md, lg, etc.).
+     * Registers a node for responsive variant updates.
+     * 
+     * This method subscribes ONCE per Scene to breakpoint changes, not per node.
+     * When the breakpoint changes, all registered nodes in that Scene are updated.
+     * 
+     * @param node The target node
+     * @param breakpoint The breakpoint name (e.g., "md", "lg")
+     * @param utility The base utility to apply when breakpoint is active
+     * @param jitCompiler JIT compiler for generating styles
      */
-    private static void applyScreenVariant(Node node, String variant, String utility, JitCompiler jitCompiler) {
-        // Para variantes responsivas, necesitamos escuchar cambios en el tamaño de la ventana
-        // Esto requiere acceso a la escena, lo cual manejaremos de forma diferida
-        
-        Integer minWidth = breakpointWidths.get(variant);
-        if (minWidth == null) {
-            // Intentar con prefijos min- y max-
-            if (variant.startsWith("min-")) {
-                String baseBreakpoint = variant.substring(4);
-                minWidth = breakpointWidths.get(baseBreakpoint);
-            } else if (variant.startsWith("max-")) {
-                String baseBreakpoint = variant.substring(4);
-                Integer maxWidth = breakpointWidths.get(baseBreakpoint);
-                if (maxWidth != null) {
-                    // Para max-, usamos maxWidth - 1
-                    minWidth = maxWidth - 1;
-                }
-            }
+    public static void bindResponsiveVariant(Node node, String breakpoint, String utility, JitCompiler jitCompiler) {
+        if (node == null || breakpoint == null || utility == null) {
+            return;
         }
         
-        if (minWidth != null) {
-            // Registrar listener para cambios de tamaño
-            registerBreakpointListener(node, variant, utility, jitCompiler, minWidth);
+        // Cache the compiled style
+        String cacheKey = breakpoint + ":" + utility;
+        JitCompiler.CompileResult result = styleCache.computeIfAbsent(cacheKey, k -> jitCompiler.compile(utility));
+        if (result == null || !result.hasInlineStyle()) {
+            return;
+        }
+        
+        // Store the binding
+        ResponsiveBinding binding = new ResponsiveBinding(node, breakpoint, result.inlineStyle());
+        
+        node.sceneProperty().addListener((obs, oldScene, newScene) -> {
+            if (oldScene != null) {
+                unregisterFromScene(oldScene, binding);
+            }
+            if (newScene != null) {
+                registerToScene(newScene, binding);
+            }
+        });
+        
+        // Register immediately if already in a scene
+        Scene currentScene = node.getScene();
+        if (currentScene != null) {
+            registerToScene(currentScene, binding);
         }
     }
     
     /**
-     * Aplica una variante de tema (dark, light).
+     * Registers a responsive binding to a Scene.
+     * Subscribes to BreakpointManager only once per Scene.
      */
-    private static void applyThemeVariant(Node node, String variant, String utility, JitCompiler jitCompiler) {
+    private static void registerToScene(Scene scene, ResponsiveBinding binding) {
+        List<ResponsiveBinding> bindings = responsiveNodes.computeIfAbsent(scene, k -> {
+            // First binding for this Scene — subscribe to breakpoint changes
+            subscribeToBreakpointChanges(scene);
+            return new ArrayList<>();
+        });
+        
+        // Avoid duplicate bindings
+        if (!bindings.contains(binding)) {
+            bindings.add(binding);
+        }
+        
+        // Apply initial state
+        applyResponsiveStyle(binding);
+    }
+    
+    /**
+     * Unregisters a responsive binding from a Scene.
+     */
+    private static void unregisterFromScene(Scene scene, ResponsiveBinding binding) {
+        List<ResponsiveBinding> bindings = responsiveNodes.get(scene);
+        if (bindings != null) {
+            bindings.remove(binding);
+            if (bindings.isEmpty()) {
+                responsiveNodes.remove(scene);
+            }
+        }
+    }
+    
+    /**
+     * Subscribes to breakpoint changes for a Scene.
+     * Called only once per Scene to avoid O(N) listeners.
+     */
+    private static void subscribeToBreakpointChanges(Scene scene) {
+        var window = scene.getWindow();
+        if (window instanceof javafx.stage.Stage) {
+            BreakpointManager bpm = BreakpointManager.from((javafx.stage.Stage) window);
+            
+            // Listen to breakpoint changes and update all nodes in this Scene
+            bpm.activeBreakpointProperty().addListener((obs, oldBp, newBp) -> {
+                List<ResponsiveBinding> bindings = responsiveNodes.get(scene);
+                if (bindings != null) {
+                    for (ResponsiveBinding binding : bindings) {
+                        applyResponsiveStyle(binding);
+                    }
+                }
+            });
+        }
+    }
+    
+    /**
+     * Applies or removes responsive style based on current breakpoint.
+     */
+    private static void applyResponsiveStyle(ResponsiveBinding binding) {
+        var scene = binding.node().getScene();
+        if (scene == null) return;
+        
+        var window = scene.getWindow();
+        if (!(window instanceof javafx.stage.Stage)) return;
+        
+        BreakpointManager.Breakpoint currentBp = BreakpointManager.from((javafx.stage.Stage) window).current();
+        int currentMinWidth = (int) currentBp.minWidth;
+        int targetMinWidth = getBreakpointMinWidth(binding.breakpoint());
+        
+        boolean isActive = currentMinWidth >= targetMinWidth;
+        
+        if (isActive) {
+            applyStyle(binding.node(), binding.style());
+        } else {
+            removeStyle(binding.node(), binding.style());
+        }
+    }
+    
+    /**
+     * Gets the minimum width for a breakpoint name.
+     */
+    private static int getBreakpointMinWidth(String breakpoint) {
+        return switch (breakpoint) {
+            case "sm" -> 640;
+            case "md" -> 768;
+            case "lg" -> 1024;
+            case "xl" -> 1280;
+            case "2xl" -> 1536;
+            default -> 0;
+        };
+    }
+    
+    /**
+     * Applies a theme variant (dark, light) to a node.
+     */
+    public static void applyThemeVariant(Node node, String variant, String utility, JitCompiler jitCompiler) {
         boolean isDark = "dark".equals(variant);
         
-        // Escuchar cambios en el tema - usar ThemeManager directamente
-        // Nota: ThemeManager no tiene getInstance(), usamos métodos estáticos
-        
-        // Aplicar inmediatamente si el tema coincide (verificar preferencia del usuario)
-        // Como no podemos acceder fácilmente al estado del tema, aplicamos diferido
         node.sceneProperty().addListener((obs, oldScene, newScene) -> {
-            if (newScene != null) {
-                // Verificar si la escena tiene modo oscuro activado
-                // Usamos una propiedad simple basada en el estilo de la escena
-                boolean sceneIsDark = newScene.getRoot() != null && 
-                    newScene.getRoot().getStyleClass().contains("dark");
+            if (newScene != null && newScene.getRoot() != null) {
+                boolean sceneIsDark = newScene.getRoot().getStyleClass().contains("dark");
                 
                 if (sceneIsDark == isDark) {
                     JitCompiler.CompileResult result = jitCompiler.compile(utility);
@@ -200,19 +258,14 @@ public class VariantManager {
     }
     
     /**
-     * Aplica una variante de grupo (group-hover, group-focus, etc.).
+     * Applies a group variant (group-hover, group-focus) to a node.
      */
-    private static void applyGroupVariant(Node node, String variant, String utility, JitCompiler jitCompiler) {
-        // Las variantes de grupo requieren encontrar el nodo padre con clase "group"
-        // Esto es complejo en JavaFX, lo implementaremos de forma simplificada
+    public static void applyGroupVariant(Node node, String variant, String utility, JitCompiler jitCompiler) {
+        String groupVariant = variant.substring(6); // Remove "group-" prefix
         
-        String groupVariant = variant.substring(6); // Remover "group-"
-        
-        // Buscar padre con clase "group"
         javafx.scene.Parent parent = node.getParent();
         while (parent != null) {
             if (parent.getStyleClass().contains("group")) {
-                // Aplicar listener al padre
                 switch (groupVariant) {
                     case "hover":
                         parent.setOnMouseEntered(e -> {
@@ -236,22 +289,19 @@ public class VariantManager {
     }
     
     /**
-     * Aplica una variante arbitraria ([@media...], [&:hover], etc.).
+     * Applies an arbitrary variant ([@media...], [&:hover]) to a node.
      */
-    private static void applyArbitraryVariant(Node node, String variant, String utility, JitCompiler jitCompiler) {
-        // Extraer contenido de la variante arbitraria
+    public static void applyArbitraryVariant(Node node, String variant, String utility, JitCompiler jitCompiler) {
         String content = variant.substring(1, variant.length() - 1);
         
-        // Si es una media query, manejar como variante responsiva
         if (content.startsWith("@media")) {
-            // Parsear la media query y aplicar listener apropiado
-            // Implementación simplificada
+            // Handle as responsive variant (simplified)
             JitCompiler.CompileResult result = jitCompiler.compile(utility);
             if (result != null && result.hasInlineStyle()) {
                 applyStyle(node, result.inlineStyle());
             }
         } else {
-            // Otras variantes arbitrarias
+            // Other arbitrary variants
             JitCompiler.CompileResult result = jitCompiler.compile(utility);
             if (result != null && result.hasInlineStyle()) {
                 applyStyle(node, result.inlineStyle());
@@ -260,38 +310,7 @@ public class VariantManager {
     }
     
     /**
-     * Registra un listener para cambios de breakpoint.
-     */
-    private static void registerBreakpointListener(Node node, String variant, String utility, 
-                                                    JitCompiler jitCompiler, int minWidth) {
-        // Esta implementación requiere acceso a la escena
-        // Se implementará cuando el nodo esté en una escena
-        
-        node.sceneProperty().addListener((obs, oldScene, newScene) -> {
-            if (newScene != null) {
-                newScene.widthProperty().addListener((widthObs, oldWidth, newWidth) -> {
-                    boolean isActive = newWidth.doubleValue() >= minWidth;
-                    JitCompiler.CompileResult result = jitCompiler.compile(utility);
-                    
-                    if (isActive && result != null && result.hasInlineStyle()) {
-                        applyStyle(node, result.inlineStyle());
-                    } else {
-                        removeStyle(node, result != null ? result.inlineStyle() : null);
-                    }
-                });
-                
-                // Evaluar inmediatamente
-                boolean isActive = newScene.getWidth() >= minWidth;
-                JitCompiler.CompileResult result = jitCompiler.compile(utility);
-                if (isActive && result != null && result.hasInlineStyle()) {
-                    applyStyle(node, result.inlineStyle());
-                }
-            }
-        });
-    }
-    
-    /**
-     * Aplica un estilo a un nodo.
+     * Applies a style to a node, avoiding duplicates.
      */
     private static void applyStyle(Node node, String style) {
         if (style == null || style.isEmpty()) {
@@ -305,7 +324,7 @@ public class VariantManager {
     }
     
     /**
-     * Remueve un estilo de un nodo.
+     * Removes a style from a node.
      */
     private static void removeStyle(Node node, String style) {
         if (style == null || style.isEmpty()) {
@@ -318,27 +337,17 @@ public class VariantManager {
     }
     
     /**
-     * Limpia los listeners de un nodo.
-     */
-    private static void cleanupListeners(Node node) {
-        List<VariantListener> listeners = nodeListeners.remove(node);
-        if (listeners != null) {
-            listeners.clear();
-        }
-    }
-    
-    /**
-     * Procesa un token con variantes y lo aplica a un nodo.
+     * Processes a token with variants and applies it to a node.
      * 
-     * @param node El nodo al que aplicar el estilo
-     * @param token El token completo (ej: "hover:bg-blue-500")
-     * @param jitCompiler El compilador JIT
+     * @param node The target node
+     * @param token The full token (e.g., "hover:bg-blue-500", "md:w-full")
+     * @param jitCompiler JIT compiler
      */
     public static void processToken(Node node, String token, JitCompiler jitCompiler) {
         VariantParser.VariantResult result = VariantParser.parse(token);
         
         if (!result.hasVariant()) {
-            // Sin variantes, aplicar directamente
+            // No variants, apply directly
             JitCompiler.CompileResult compileResult = jitCompiler.compile(token);
             if (compileResult != null && compileResult.hasInlineStyle()) {
                 applyStyle(node, compileResult.inlineStyle());
@@ -346,12 +355,40 @@ public class VariantManager {
             return;
         }
         
-        // Tiene variantes, procesar cada una
         List<String> variants = result.getVariants();
         String utility = result.getUtility();
-        
-        // Aplicar la última variante (la más específica)
         String lastVariant = variants.get(variants.size() - 1);
-        applyVariant(node, lastVariant, utility, jitCompiler);
+        
+        // Route to appropriate handler based on variant type
+        String variantType = VariantParser.getVariantType(lastVariant);
+        
+        switch (variantType) {
+            case "state":
+                applyStateVariant(node, lastVariant, utility, jitCompiler);
+                break;
+            case "screen":
+                bindResponsiveVariant(node, lastVariant, utility, jitCompiler);
+                break;
+            case "theme":
+                applyThemeVariant(node, lastVariant, utility, jitCompiler);
+                break;
+            case "group":
+                applyGroupVariant(node, lastVariant, utility, jitCompiler);
+                break;
+            case "arbitrary":
+                applyArbitraryVariant(node, lastVariant, utility, jitCompiler);
+                break;
+            default:
+                // Unknown variant, apply directly
+                JitCompiler.CompileResult compileResult = jitCompiler.compile(utility);
+                if (compileResult != null && compileResult.hasInlineStyle()) {
+                    applyStyle(node, compileResult.inlineStyle());
+                }
+        }
     }
+    
+    /**
+     * Record representing a responsive binding between a node and a breakpoint.
+     */
+    private record ResponsiveBinding(Node node, String breakpoint, String style) {}
 }


### PR DESCRIPTION

- BreakpointManager: Centralized publisher with single listener per Stage
  * Added activeBreakpointProperty() for reactive subscriptions
  * Implemented instance caching to prevent duplicate managers
  * Maintained throttling (120ms) to avoid resize thrashing
  * All comments and documentation in English

- VariantManager: Subscriber that binds once per Scene, not per node
  * Removed O(N) width listeners that caused performance issues
  * Uses WeakHashMap to prevent memory leaks
  * Routes responsive variants through BreakpointManager property
  * Separates concerns: state/theme/group variants vs responsive variants

Architecture benefits:
- Performance: Reduced from O(N) listeners to O(1) per Stage
- Memory: Proper cleanup with WeakHashMap and instance cache removal
- Maintainability: Clear separation between detection and application
- Fidelity: Follows Tailwind CSS responsive model accurately