### PR TITLE
feat: implement scroll-snap utilities (#29)

### DIFF
--- a/src/main/java/io/github/yasmramos/tailwindfx/style/Styles.java
+++ b/src/main/java/io/github/yasmramos/tailwindfx/style/Styles.java
@@ -447,6 +447,82 @@ public final class Styles {
     }
 
     // =========================================================================
+    // SCROLL SNAP — snap-x, snap-y, snap-both, snap-start, snap-center
+    // =========================================================================
+
+    public static <T extends Node> T snapNone(T node) {
+        Preconditions.requireNode(node, "Styles.snapNone");
+        node.getStyleClass().add("snap-none");
+        return node;
+    }
+
+    public static <T extends Node> T snapX(T node) {
+        Preconditions.requireNode(node, "Styles.snapX");
+        node.getStyleClass().add("snap-x");
+        return node;
+    }
+
+    public static <T extends Node> T snapY(T node) {
+        Preconditions.requireNode(node, "Styles.snapY");
+        node.getStyleClass().add("snap-y");
+        return node;
+    }
+
+    public static <T extends Node> T snapBoth(T node) {
+        Preconditions.requireNode(node, "Styles.snapBoth");
+        node.getStyleClass().add("snap-both");
+        return node;
+    }
+
+    public static <T extends Node> T snapMandatory(T node) {
+        Preconditions.requireNode(node, "Styles.snapMandatory");
+        node.getStyleClass().add("snap-mandatory");
+        return node;
+    }
+
+    public static <T extends Node> T snapProximity(T node) {
+        Preconditions.requireNode(node, "Styles.snapProximity");
+        node.getStyleClass().add("snap-proximity");
+        return node;
+    }
+
+    public static <T extends Node> T snapStart(T node) {
+        Preconditions.requireNode(node, "Styles.snapStart");
+        node.getStyleClass().add("snap-start");
+        return node;
+    }
+
+    public static <T extends Node> T snapEnd(T node) {
+    Preconditions.requireNode(node, "Styles.snapEnd");
+    node.getStyleClass().add("snap-end");
+    return node;
+    }
+
+    public static <T extends Node> T snapCenter(T node) {
+        Preconditions.requireNode(node, "Styles.snapCenter");
+        node.getStyleClass().add("snap-center");
+        return node;
+    }
+
+    public static <T extends Node> T snapAlignNone(T node) {
+        Preconditions.requireNode(node, "Styles.snapAlignNone");
+        node.getStyleClass().add("snap-align-none");
+        return node;
+    }
+
+    public static <T extends Node> T snapNormal(T node) {
+        Preconditions.requireNode(node, "Styles.snapNormal");
+        node.getStyleClass().add("snap-normal");
+        return node;
+    }
+
+    public static <T extends Node> T snapAlways(T node) {
+        Preconditions.requireNode(node, "Styles.snapAlways");
+        node.getStyleClass().add("snap-always");
+        return node;
+    }
+    
+    // =========================================================================
     // SELF ALIGNMENT — self-start, self-center, self-end, self-stretch
     // Corresponde a: align-self en CSS web (GridPane)
     // =========================================================================
@@ -577,8 +653,9 @@ public final class Styles {
     }
 
     /** Elimina todos los filtros ColorAdjust del nodo */
-    public static <T extends Node> T filterNone(T node) {
-        if (node.getEffect() instanceof ColorAdjust) node.setEffect(null);
+    public static <T extends Node> T snapEnd(T node) {
+        Preconditions.requireNode(node, "Styles.snapEnd");
+        node.getStyleClass().add("snap-end");
         return node;
     }
 

--- a/src/main/resources/tailwindfx/tailwindfx-utilities.css
+++ b/src/main/resources/tailwindfx/tailwindfx-utilities.css
@@ -314,6 +314,28 @@
 .overflow-auto { -fx-overflow: auto; }
 
 /* =============================================================================
+ * SCROLL SNAP
+ * ============================================================================= */
+
+/* Scroll Snap Type */
+.snap-none { -fx-scroll-snap-type: none; }
+.snap-x { -fx-scroll-snap-type: x mandatory; }
+.snap-y { -fx-scroll-snap-type: y mandatory; }
+.snap-both { -fx-scroll-snap-type: both mandatory; }
+.snap-mandatory { -fx-scroll-snap-type: mandatory; }
+.snap-proximity { -fx-scroll-snap-type: proximity; }
+
+/* Scroll Snap Align */
+.snap-start { -fx-scroll-snap-align: start; }
+.snap-end { -fx-scroll-snap-align: end; }
+.snap-center { -fx-scroll-snap-align: center; }
+.snap-align-none { -fx-scroll-snap-align: none; }
+
+/* Scroll Snap Stop */
+.snap-normal { -fx-scroll-snap-stop: normal; }
+.snap-always { -fx-scroll-snap-stop: always; }
+
+/* =============================================================================
  * CURSOR
  * ============================================================================= */
 


### PR DESCRIPTION
## Summary
Implemented scroll-snap utilities for TailwindFX:
- scroll-snap-type
- scroll-snap-align
- scroll-snap-stop

## Changes
- Added CSS utilities
- Added Styles.java API methods
- Integrated with existing section structure

Closes #29