### PR TITLE
feat(css): add TailwindCSS touch-action utilities

### DIFF
--- a/src/main/resources/tailwindfx/tailwindfx.css
+++ b/src/main/resources/tailwindfx/tailwindfx.css
@@ -9524,8 +9524,30 @@ Group {
 
 /* Scroll snap — no JavaFX CSS equivalent, handle with ScrollPane in Java */
 
-/* Touch action — no JavaFX CSS equivalent */
+/* Touch action — JavaFX has no `-fx-touch-action` property; gesture
+ * dispatch is controlled at the Node API level (e.g. `setOnSwipeLeft`,
+ * `setMouseTransparent`, gesture-event consumption). The web semantics
+ * map to JavaFX as follows:
+ *
+ *   .touch-none       → block all touch hits (closest signal:
+ *                       -fx-mouse-transparent: true)
+ *   .touch-auto       → default behaviour (mouse/touch hits flow normally)
+ *   .touch-pan-x      → no JavaFX CSS analog; callers must consume non-X
+ *                       gestures in their event handlers
+ *   .touch-pan-y      → same; consume non-Y gestures in event handlers
+ *   .touch-pinch-zoom → same; allow ZoomEvent dispatch and consume the
+ *                       rest in event handlers
+ *
+ * Browser/device compatibility: irrelevant — these classes ship only to
+ * JavaFX scenes, never to a browser. The pan-x / pan-y / pinch-zoom
+ * variants exist so contributors copying a TailwindCSS markup pattern
+ * don't break on missing class names; they intentionally do not change
+ * JavaFX behaviour. */
 .touch-none       { -fx-mouse-transparent: true; }
+.touch-auto       { -fx-mouse-transparent: false; }
+.touch-pan-x      { /* no-op: gesture filtering belongs in the Node API */ }
+.touch-pan-y      { /* no-op: gesture filtering belongs in the Node API */ }
+.touch-pinch-zoom { /* no-op: gesture filtering belongs in the Node API */ }
 
 /* User select */
 .select-none  { -fx-focus-traversable: false; }


### PR DESCRIPTION
## Summary

Resolves #24. Adds the four missing touch-action classes alongside the existing `.touch-none` in `src/main/resources/tailwindfx/tailwindfx.css`.

## Why this matters

The existing file already had `.touch-none` with the comment "Touch action — no JavaFX CSS equivalent" and a single mapping to `-fx-mouse-transparent: true`. Any contributor copy-pasting a TailwindCSS markup pattern that uses `touch-auto`, `touch-pan-x`, `touch-pan-y`, or `touch-pinch-zoom` would hit a missing class. JavaFX has no `-fx-touch-action` property — gesture dispatch is at the Node API level (`setOnSwipeLeft`, `setMouseTransparent`, gesture-event consumption) — so I followed the precedent the maintainer set with the cursor utilities (PR #18, merged 2026-04-25): map to the closest in-toolkit JavaFX behaviour with a comment documenting any limitations, never force a fake JavaFX rule that pretends to do something it can't.

## Changes

- `.touch-none` keeps its existing mapping: `-fx-mouse-transparent: true` (closest signal for blocking touch hits).
- `.touch-auto` mirrors the web default with `-fx-mouse-transparent: false`, matching the precedent already set by the file's `.pointer-events-auto`.
- `.touch-pan-x`, `.touch-pan-y`, and `.touch-pinch-zoom` are no-op rules with a documented comment block. They exist so callers copying a TailwindCSS markup pattern don't break on missing class names; gesture filtering belongs in the JavaFX Node API rather than CSS.
- The comment block at the top of the section also documents browser/device compatibility per the issue's third checklist item: it's irrelevant because these classes ship only to JavaFX scenes, never to a browser.

## Testing

- `mvn -q -DskipTests compile` — clean.
- Visual verification of the rendered class names: `grep -B2 -A6 "Touch action" src/main/resources/tailwindfx/tailwindfx.css` shows all five rules grouped together with the explanatory comment.
- I do not have a touch-enabled JavaFX device, so the issue's optional second checklist item ("Test on touch-enabled devices if possible") is left to the maintainer.

Fixes #24
