### PR TITLE
Fix false positive conflict between bg-gradient and bg-color utilities



### DIFF
--- a/src/main/java/io/github/yasmramos/tailwindfx/core/UtilityConflictResolver.java
+++ b/src/main/java/io/github/yasmramos/tailwindfx/core/UtilityConflictResolver.java
@@ -58,6 +58,7 @@ public final class UtilityConflictResolver {
         definitions.put("padding", new String[]{"p-", "px-", "py-", "pt-", "pr-", "pb-", "pl-"});
 
         // Colores de fondo
+        definitions.put("bg-gradient", new String[]{"bg-gradient-to-r","bg-gradient-to-l","bg-gradient-to-t","bg-gradient-to-b","bg-gradient-to-tr","bg-gradient-to-tl","bg-gradient-to-br","bg-gradient-to-bl"});
         definitions.put("bg-color", new String[]{"bg-slate-","bg-gray-","bg-red-","bg-orange-","bg-amber-",
             "bg-yellow-","bg-lime-","bg-green-","bg-emerald-","bg-teal-","bg-cyan-","bg-sky-",
             "bg-blue-","bg-indigo-","bg-violet-","bg-purple-","bg-fuchsia-","bg-pink-","bg-rose-",


### PR DESCRIPTION
- Add separate bg-gradient category to prevent incorrect conflict resolution
  between gradient utilities (bg-gradient-to-r, etc.) and color utilities (bg-blue-500, etc.)
- This ensures gradients and solid colors can coexist without one removing the other
- All tests pass