### PR TITLE
feat: add foundational builder module with initial JavaFX application window

### DIFF
--- a/builder/README.md
+++ b/builder/README.md
@@ -1,0 +1,16 @@
+# TailwindFX Builder Module
+
+This module provides the foundational structure for the upcoming standalone drag-and-drop visual builder for JavaFX layouts using TailwindFX.
+
+## Initial Scope
+- Main application window
+- Toolbar
+- Canvas workspace
+- Base architecture for future builder components
+
+## Planned Features
+- Component palette
+- Properties panel
+- Drag-and-drop editor
+- Live preview
+- Code export

--- a/builder/pom.xml
+++ b/builder/pom.xml
@@ -1,0 +1,20 @@
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0
+         https://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <groupId>io.github.tailwindfx</groupId>
+    <artifactId>builder</artifactId>
+    <version>1.0-SNAPSHOT</version>
+    <packaging>jar</packaging>
+
+    <name>TailwindFX Builder</name>
+
+    <properties>
+        <maven.compiler.source>17</maven.compiler.source>
+        <maven.compiler.target>17</maven.compiler.target>
+    </properties>
+
+</project>

--- a/builder/src/main/java/io/github/tailwindfx/builder/BuilderApp.java
+++ b/builder/src/main/java/io/github/tailwindfx/builder/BuilderApp.java
@@ -1,0 +1,36 @@
+package io.github.tailwindfx.builder;
+
+import javafx.application.Application;
+import javafx.scene.Scene;
+import javafx.scene.control.Label;
+import javafx.scene.control.ToolBar;
+import javafx.scene.layout.BorderPane;
+import javafx.scene.layout.StackPane;
+import javafx.stage.Stage;
+
+public class BuilderApp extends Application {
+
+    @Override
+    public void start(Stage stage) {
+        BorderPane root = new BorderPane();
+
+        ToolBar toolBar = new ToolBar();
+        toolBar.getItems().add(new Label("TailwindFX Builder"));
+
+        StackPane canvas = new StackPane();
+        canvas.getChildren().add(new Label("Canvas Area"));
+
+        root.setTop(toolBar);
+        root.setCenter(canvas);
+
+        Scene scene = new Scene(root, 1200, 800);
+
+        stage.setTitle("TailwindFX Visual Builder");
+        stage.setScene(scene);
+        stage.show();
+    }
+
+    public static void main(String[] args) {
+        launch();
+    }
+}

--- a/pom.xml
+++ b/pom.xml
@@ -1,10 +1,19 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<project xmlns="http://maven.apache.org/POM/4.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+         xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
     <modelVersion>4.0.0</modelVersion>
+
     <groupId>io.github.yasmramos</groupId>
     <artifactId>tailwindfx</artifactId>
     <version>1.0-SNAPSHOT</version>
-    <packaging>jar</packaging>
+    <packaging>pom</packaging>
+
+    <modules>
+        <module>builder</module>
+    </modules>
+
     <properties>
         <project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
         <maven.compiler.source>17</maven.compiler.source>
@@ -16,22 +25,26 @@
         <jacoco.version>0.8.14</jacoco.version>
         <surefire.version>3.2.5</surefire.version>
     </properties>
+
     <dependencies>
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-controls</artifactId>
             <version>${javafx.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-graphics</artifactId>
             <version>${javafx.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-base</artifactId>
             <version>${javafx.version}</version>
         </dependency>
+
         <dependency>
             <groupId>org.openjfx</groupId>
             <artifactId>javafx-fxml</artifactId>
@@ -45,30 +58,35 @@
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.junit.jupiter</groupId>
             <artifactId>junit-jupiter-params</artifactId>
             <version>${junit.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>testfx-junit5</artifactId>
             <version>${testfx.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.testfx</groupId>
             <artifactId>openjfx-monocle</artifactId>
             <version>jdk-12.0.1+2</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-core</artifactId>
             <version>${mockito.version}</version>
             <scope>test</scope>
         </dependency>
+
         <dependency>
             <groupId>org.mockito</groupId>
             <artifactId>mockito-junit-jupiter</artifactId>
@@ -76,8 +94,10 @@
             <scope>test</scope>
         </dependency>
     </dependencies>
+
     <build>
         <plugins>
+
             <plugin>
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-jar-plugin</artifactId>
@@ -108,6 +128,7 @@
                         --add-opens javafx.graphics/com.sun.prism=ALL-UNNAMED
                         --add-opens javafx.controls/com.sun.javafx.scene.control=ALL-UNNAMED
                     </argLine>
+
                     <systemPropertyVariables>
                         <testfx.robot>glass</testfx.robot>
                         <testfx.headless>true</testfx.headless>
@@ -118,64 +139,37 @@
                 </configuration>
             </plugin>
 
-            <!-- JaCoCo Plugin for Code Coverage -->
+            <!-- JaCoCo Plugin -->
             <plugin>
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
+
                 <executions>
-                    <!-- Prepare JaCoCo agent before tests run -->
                     <execution>
                         <id>prepare-agent</id>
                         <goals>
                             <goal>prepare-agent</goal>
                         </goals>
+
                         <configuration>
                             <destFile>${project.build.directory}/jacoco.exec</destFile>
                             <propertyName>jacoco.argLine</propertyName>
                         </configuration>
                     </execution>
-                    <!-- Generate coverage report after tests run -->
+
                     <execution>
                         <id>report</id>
                         <phase>test</phase>
                         <goals>
                             <goal>report</goal>
                         </goals>
+
                         <configuration>
                             <dataFile>${project.build.directory}/jacoco.exec</dataFile>
                             <outputDirectory>${project.reporting.outputDirectory}/jacoco</outputDirectory>
                         </configuration>
                     </execution>
-                    <!-- Coverage check disabled - tests pass, coverage will improve over time -->
-                    <!--
-                    <execution>
-                        <id>jacoco-check</id>
-                        <goals>
-                            <goal>check</goal>
-                        </goals>
-                        <configuration>
-                            <dataFile>${project.build.directory}/jacoco.exec</dataFile>
-                            <rules>
-                                <rule>
-                                    <element>PACKAGE</element>
-                                    <limits>
-                                        <limit>
-                                            <counter>LINE</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.10</minimum>
-                                        </limit>
-                                        <limit>
-                                            <counter>BRANCH</counter>
-                                            <value>COVEREDRATIO</value>
-                                            <minimum>0.05</minimum>
-                                        </limit>
-                                    </limits>
-                                </rule>
-                            </rules>
-                        </configuration>
-                    </execution>
-                    -->
                 </executions>
             </plugin>
 
@@ -184,15 +178,15 @@
                 <groupId>org.apache.maven.plugins</groupId>
                 <artifactId>maven-compiler-plugin</artifactId>
                 <version>3.11.0</version>
+
                 <configuration>
                     <source>17</source>
                     <target>17</target>
                 </configuration>
             </plugin>
+
         </plugins>
     </build>
-
-
 
     <reporting>
         <plugins>
@@ -200,6 +194,7 @@
                 <groupId>org.jacoco</groupId>
                 <artifactId>jacoco-maven-plugin</artifactId>
                 <version>${jacoco.version}</version>
+
                 <reportSets>
                     <reportSet>
                         <reports>
@@ -210,4 +205,5 @@
             </plugin>
         </plugins>
     </reporting>
+
 </project>


### PR DESCRIPTION
## Summary

This PR introduces the foundational builder module structure for the TailwindFX standalone visual builder.

### Changes Made

* Added new `builder` Maven module
* Added module README with scope and roadmap
* Added `builder/pom.xml` for module configuration
* Created `BuilderApp.java` JavaFX entry point
* Added initial main window with toolbar and canvas placeholder
* Updated root Maven configuration to register builder module

### Why

This establishes the base architecture for incremental development of the TailwindFX drag-and-drop builder, enabling future work on component palettes, properties panels, layout editing, and export systems.
