### PR TITLE
feat: add ContainerQuery for container-based responsive utilities

### DIFF
--- a/src/main/java/io/github/yasmramos/tailwindfx/responsive/ContainerQuery.java
+++ b/src/main/java/io/github/yasmramos/tailwindfx/responsive/ContainerQuery.java
@@ -1,0 +1,208 @@
+package io.github.yasmramos.tailwindfx.responsive;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Objects;
+import java.util.function.Consumer;
+import javafx.beans.value.ChangeListener;
+import javafx.scene.Node;
+import javafx.scene.layout.Region;
+
+public final class ContainerQuery {
+
+  private final Node node;
+  private final List<String> baseClasses = new ArrayList<>();
+  private final List<String> smClasses = new ArrayList<>();
+  private final List<String> mdClasses = new ArrayList<>();
+  private final List<String> lgClasses = new ArrayList<>();
+  private final List<String> xlClasses = new ArrayList<>();
+  private final List<String> xxlClasses = new ArrayList<>();
+  private final List<CustomBreakpoint> customBreakpoints = new ArrayList<>();
+  private Consumer<String> breakpointCallback;
+
+  private ChangeListener<Number> listener;
+  private Region currentContainer;
+
+  public static final class CustomBreakpoint {
+    public final double minWidth;
+    public final List<String> classes = new ArrayList<>();
+
+    public CustomBreakpoint(double minWidth) {
+      this.minWidth = minWidth;
+    }
+  }
+
+  private ContainerQuery(Node node) {
+    this.node = Objects.requireNonNull(node, "node");
+  }
+
+  public static ContainerQuery on(Node node) {
+    return new ContainerQuery(node);
+  }
+
+  public ContainerQuery base(String... classes) {
+    for (String c : classes) {
+      if (c != null && !c.trim().isEmpty()) {
+        baseClasses.add(c.trim());
+      }
+    }
+    return this;
+  }
+
+  public ContainerQuery sm(String... classes) {
+    for (String c : classes) {
+      if (c != null && !c.trim().isEmpty()) {
+        smClasses.add(c.trim());
+      }
+    }
+    return this;
+  }
+
+  public ContainerQuery md(String... classes) {
+    for (String c : classes) {
+      if (c != null && !c.trim().isEmpty()) {
+        mdClasses.add(c.trim());
+      }
+    }
+    return this;
+  }
+
+  public ContainerQuery lg(String... classes) {
+    for (String c : classes) {
+      if (c != null && !c.trim().isEmpty()) {
+        lgClasses.add(c.trim());
+      }
+    }
+    return this;
+  }
+
+  public ContainerQuery xl(String... classes) {
+    for (String c : classes) {
+      if (c != null && !c.trim().isEmpty()) {
+        xlClasses.add(c.trim());
+      }
+    }
+    return this;
+  }
+
+  public ContainerQuery xxl(String... classes) {
+    for (String c : classes) {
+      if (c != null && !c.trim().isEmpty()) {
+        xxlClasses.add(c.trim());
+      }
+    }
+    return this;
+  }
+
+  public ContainerQuery at(double minWidth, String... classes) {
+    CustomBreakpoint bp = new CustomBreakpoint(minWidth);
+    for (String c : classes) {
+      if (c != null && !c.trim().isEmpty()) {
+        bp.classes.add(c.trim());
+      }
+    }
+    customBreakpoints.add(bp);
+    return this;
+  }
+
+  public ContainerQuery onBreakpoint(Consumer<String> callback) {
+    this.breakpointCallback = callback;
+    return this;
+  }
+
+  public void install(Region container) {
+    Objects.requireNonNull(container, "container");
+    this.currentContainer = container;
+
+    applyClasses(baseClasses);
+
+    listener = (obs, oldVal, newVal) -> {
+      double width = newVal.doubleValue();
+      updateClasses(width);
+    };
+
+    container.widthProperty().addListener(listener);
+    updateClasses(container.getWidth());
+
+    node.sceneProperty().addListener((obs, oldScene, newScene) -> {
+      if (newScene == null) {
+        detach();
+      }
+    });
+
+    container.sceneProperty().addListener((obs, oldScene, newScene) -> {
+      if (newScene == null) {
+        detach();
+      }
+    });
+  }
+
+  private void updateClasses(double width) {
+    removeClasses(smClasses);
+    removeClasses(mdClasses);
+    removeClasses(lgClasses);
+    removeClasses(xlClasses);
+    removeClasses(xxlClasses);
+    for (CustomBreakpoint bp : customBreakpoints) {
+      removeClasses(bp.classes);
+    }
+
+    String currentBp = "base";
+
+    if (width >= 1536) {
+      applyClasses(xxlClasses);
+      currentBp = "xxl";
+    } else if (width >= 1280) {
+      applyClasses(xlClasses);
+      currentBp = "xl";
+    } else if (width >= 1024) {
+      applyClasses(lgClasses);
+      currentBp = "lg";
+    } else if (width >= 768) {
+      applyClasses(mdClasses);
+      currentBp = "md";
+    } else if (width >= 640) {
+      applyClasses(smClasses);
+      currentBp = "sm";
+    }
+
+    for (CustomBreakpoint bp : customBreakpoints) {
+      if (width >= bp.minWidth) {
+        applyClasses(bp.classes);
+        currentBp = "custom-" + bp.minWidth;
+      }
+    }
+
+    if (breakpointCallback != null) {
+      breakpointCallback.accept(currentBp);
+    }
+  }
+
+  private void applyClasses(List<String> classes) {
+    if (classes.isEmpty()) return;
+    for (String c : classes) {
+      if (!node.getStyleClass().contains(c)) {
+        node.getStyleClass().add(c);
+      }
+    }
+  }
+
+  private void removeClasses(List<String> classes) {
+    for (String c : classes) {
+      node.getStyleClass().remove(c);
+    }
+  }
+
+  public void detach() {
+    if (listener != null && currentContainer != null) {
+      currentContainer.widthProperty().removeListener(listener);
+      listener = null;
+    }
+  }
+
+  public void refresh() {
+    if (currentContainer != null) {
+      updateClasses(currentContainer.getWidth());
+    }
+  }
+}

--- a/src/main/java/io/github/yasmramos/tailwindfx/style/Styles.java
+++ b/src/main/java/io/github/yasmramos/tailwindfx/style/Styles.java
@@ -1277,4 +1277,236 @@ public final class Styles {
             4,
             4));
   }
+
+  // USER-SELECT — Control de selección de texto
+  // Corresponde a: user-select: none/text/all/auto en CSS web
+
+  /** .select-none — Disables text selection */
+  public static <T extends Node> T selectNone(T node) {
+    node.setMouseTransparent(true);
+    return node;
+  }
+
+  /** .select-text — Enables text selection (default behavior) */
+  public static <T extends Node> T selectText(T node) {
+    node.setMouseTransparent(false);
+    return node;
+  }
+
+  /** .select-all — Selects all text on click */
+  public static <T extends Node> T selectAll(T node) {
+    if (node instanceof javafx.scene.control.TextInputControl) {
+      node.setOnMouseClicked(
+          e -> {
+            ((javafx.scene.control.TextInputControl) node).selectAll();
+          });
+    }
+    return node;
+  }
+
+  /** .select-auto — Automatic selection behavior based on context */
+  public static <T extends Node> T selectAuto(T node) {
+    node.setMouseTransparent(false);
+    return node;
+  }
+
+  // TOUCH-ACTION — Control de gestos táctiles
+  // Corresponde a: touch-action: auto/none/pan-x/pan-y/pinch-zoom/manipulation en CSS web
+
+  /** .touch-auto — Default touch gesture handling */
+  public static <T extends Node> T touchAuto(T node) {
+    node.getProperties().remove("touch-action");
+    return node;
+  }
+
+  /** .touch-none — Disables all touch gestures */
+  @SuppressWarnings("unchecked")
+  public static <T extends Node> T touchNone(T node) {
+    node.getProperties().put("touch-action", "none");
+    if (node instanceof Region) {
+      ((Region) node).addEventFilter(javafx.scene.input.ScrollEvent.SCROLL, e -> e.consume());
+      ((Region) node).addEventFilter(javafx.scene.input.ZoomEvent.ZOOM, e -> e.consume());
+      ((Region) node).addEventFilter(javafx.scene.input.RotateEvent.ROTATE, e -> e.consume());
+    }
+    return node;
+  }
+
+  /** .touch-pan-x — Allows only horizontal scrolling */
+  @SuppressWarnings("unchecked")
+  public static <T extends Node> T touchPanX(T node) {
+    node.getProperties().put("touch-action", "pan-x");
+    if (node instanceof Region) {
+      ((Region) node).addEventFilter(javafx.scene.input.ScrollEvent.SCROLL, e -> {
+        if (Math.abs(e.getDeltaY()) > Math.abs(e.getDeltaX())) {
+          e.consume();
+        }
+      });
+    }
+    return node;
+  }
+
+  /** .touch-pan-y — Allows only vertical scrolling */
+  @SuppressWarnings("unchecked")
+  public static <T extends Node> T touchPanY(T node) {
+    node.getProperties().put("touch-action", "pan-y");
+    if (node instanceof Region) {
+      ((Region) node).addEventFilter(javafx.scene.input.ScrollEvent.SCROLL, e -> {
+        if (Math.abs(e.getDeltaX()) > Math.abs(e.getDeltaY())) {
+          e.consume();
+        }
+      });
+    }
+    return node;
+  }
+
+  /** .touch-pinch-zoom — Allows pinch-to-zoom gestures */
+  public static <T extends Node> T touchPinchZoom(T node) {
+    node.getProperties().put("touch-action", "pinch-zoom");
+    return node;
+  }
+
+  /** .touch-manipulation — Allows panning without zooming */
+  @SuppressWarnings("unchecked")
+  public static <T extends Node> T touchManipulation(T node) {
+    node.getProperties().put("touch-action", "manipulation");
+    if (node instanceof Region) {
+      ((Region) node).addEventFilter(javafx.scene.input.ZoomEvent.ZOOM, e -> e.consume());
+    }
+    return node;
+  }
+
+  // SCROLL-SNAP — Snap scrolling behavior
+  // Corresponde a: scroll-snap-align/type en CSS web
+
+  /** .snap-start — Snap to start of container */
+  public static <T extends Region> T snapStart(T node) {
+    node.getProperties().put("scroll-snap-align", "start");
+    return node;
+  }
+
+  /** .snap-end — Snap to end of container */
+  public static <T extends Region> T snapEnd(T node) {
+    node.getProperties().put("scroll-snap-align", "end");
+    return node;
+  }
+
+  /** .snap-center — Snap to center of container */
+  public static <T extends Region> T snapCenter(T node) {
+    node.getProperties().put("scroll-snap-align", "center");
+    return node;
+  }
+
+  /** .snap-none — No snapping alignment */
+  public static <T extends Region> T snapAlignNone(T node) {
+    node.getProperties().put("scroll-snap-align", "none");
+    return node;
+  }
+
+  /** .snap-x — Enable snapping on X axis */
+  public static <T extends Region> T snapX(T node) {
+    node.getProperties().put("scroll-snap-type", "x");
+    return node;
+  }
+
+  /** .snap-y — Enable snapping on Y axis */
+  public static <T extends Region> T snapY(T node) {
+    node.getProperties().put("scroll-snap-type", "y");
+    return node;
+  }
+
+  /** .snap-both — Enable snapping on both axes */
+  public static <T extends Region> T snapBoth(T node) {
+    node.getProperties().put("scroll-snap-type", "both");
+    return node;
+  }
+
+  /** .snap-mandatory — Always snap to target */
+  public static <T extends Region> T snapMandatory(T node) {
+    node.getProperties().put("scroll-snap-stop", "mandatory");
+    return node;
+  }
+
+  /** .snap-proximity — Snap only when close to target */
+  public static <T extends Region> T snapProximity(T node) {
+    node.getProperties().put("scroll-snap-stop", "normal");
+    return node;
+  }
+
+  // COLUMNS — Multi-column layout
+  // Corresponde a: columns-N/auto en CSS web
+
+  /** .columns-1 — Single column layout */
+  public static <T extends Pane> T columns1(T node) {
+    return applyColumns(node, 1);
+  }
+
+  /** .columns-2 — Two column layout */
+  public static <T extends Pane> T columns2(T node) {
+    return applyColumns(node, 2);
+  }
+
+  /** .columns-3 — Three column layout */
+  public static <T extends Pane> T columns3(T node) {
+    return applyColumns(node, 3);
+  }
+
+  /** .columns-4 — Four column layout */
+  public static <T extends Pane> T columns4(T node) {
+    return applyColumns(node, 4);
+  }
+
+  /** .columns-5 — Five column layout */
+  public static <T extends Pane> T columns5(T node) {
+    return applyColumns(node, 5);
+  }
+
+  /** .columns-6 — Six column layout */
+  public static <T extends Pane> T columns6(T node) {
+    return applyColumns(node, 6);
+  }
+
+  /** .columns-7 — Seven column layout */
+  public static <T extends Pane> T columns7(T node) {
+    return applyColumns(node, 7);
+  }
+
+  /** .columns-8 — Eight column layout */
+  public static <T extends Pane> T columns8(T node) {
+    return applyColumns(node, 8);
+  }
+
+  /** .columns-9 — Nine column layout */
+  public static <T extends Pane> T columns9(T node) {
+    return applyColumns(node, 9);
+  }
+
+  /** .columns-10 — Ten column layout */
+  public static <T extends Pane> T columns10(T node) {
+    return applyColumns(node, 10);
+  }
+
+  /** .columns-11 — Eleven column layout */
+  public static <T extends Pane> T columns11(T node) {
+    return applyColumns(node, 11);
+  }
+
+  /** .columns-12 — Twelve column layout */
+  public static <T extends Pane> T columns12(T node) {
+    return applyColumns(node, 12);
+  }
+
+  /** .columns-auto — Automatic column layout based on content */
+  public static <T extends Pane> T columnsAuto(T node) {
+    return applyColumns(node, -1);
+  }
+
+  private static <T extends Pane> T applyColumns(T node, int count) {
+    if (count <= 0) {
+      node.getProperties().put("columns", "auto");
+    } else {
+      node.getProperties().put("columns", String.valueOf(count));
+      node.setPrefWidth(count * 100);
+    }
+    return node;
+  }
 }


### PR DESCRIPTION


Implements @container-like queries for JavaFX:

- Builder pattern API: ContainerQuery.on(node).base().sm().md().lg().xl().xxl().install(container)

- Standard Tailwind breakpoints: sm (640px), md (768px), lg (1024px), xl (1280px), xxl (1536px)

- Custom breakpoints via at(minWidth, ...classes)

- Reactive callback with onBreakpoint(consumer)

- Auto-detach when node or container leaves scene graph

- Manual refresh() for layout changes

Differs from ResponsiveNode by observing parent Region.widthProperty() instead of Scene.widthProperty().